### PR TITLE
Production Update - Truncate attachment titles if too long

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ AhjoApiServiceUnitTests/bin/
 AhjoApiServiceUnitTests/obj/
 .gitignore.bak
 Dockerfile.bak
+exampleMessages/
 README.md.bak

--- a/AhjoApiService/AhjoToStorageMapper.cs
+++ b/AhjoApiService/AhjoToStorageMapper.cs
@@ -12,7 +12,8 @@ namespace AhjoApiService
             var result = new List<StorageMeetingDTO>();
             var config = new MapperConfiguration(cfg =>
             {
-                cfg.CreateMap<AhjoAttachmentDTO, StorageAttachmentDTO>();
+                cfg.CreateMap<AhjoAttachmentDTO, StorageAttachmentDTO>()
+                    .ForMember(dest => dest.Title, opt => opt.MapFrom(src => TruncateAttachmentTitle(src)));
                 cfg.CreateMap<AhjoFullDecisionDTO, StorageDecisionDTO>()
                     .ForMember(dest => dest.Language, opt => opt.MapFrom(src => GetLanguageFromPdf(src.Pdf)))
                     .ForMember(dest => dest.Html, opt => opt.MapFrom(src => src.Content));
@@ -37,9 +38,19 @@ namespace AhjoApiService
             return result;
         }
 
+        private static string? TruncateAttachmentTitle(AhjoAttachmentDTO attachment)
+        {
+            const int MAX_DB_TITLE_LENGTH = 256;
+            if (attachment?.Title == null)
+                return null;
+            return attachment.Title.Length > MAX_DB_TITLE_LENGTH
+                ? attachment.Title.Substring(0, MAX_DB_TITLE_LENGTH)
+                : attachment.Title;
+        }
+
         private static string GetLanguageFromPdf(AhjoAttachmentDTO pdf)
         {
-            if(pdf != null)
+            if (pdf != null)
             {
                 return pdf.Language;
             }

--- a/AhjoApiService/Program.cs
+++ b/AhjoApiService/Program.cs
@@ -73,7 +73,7 @@ namespace AhjoApiService
 
             const int PollingTime = 1000 * 60 * 60;
             const int DaysInOneTry = 7;
-            var startDate = DateTime.UtcNow.AddDays(1);
+            var startDate = DateTime.UtcNow.AddDays(-3); // Temporarily start searching 3 days ago
             while (true)
             {
                 var meetings = await apiReader.GetMeetingsData(startDate, startDate.AddDays(DaysInOneTry));


### PR DESCRIPTION
Too long attachment title names caused errors when saving data to the database. Add Truncate function to trim them down to the max length of 256.

Temporarily allow pump to fetch held meetings in order to fetch a meeting that was held already